### PR TITLE
Initial review for the new slack router service.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: clojure
+sudo: false
+jdk:
+- oraclejdk8
+lein: 2.7.1
+addons:
+  rethinkdb: '2.3.6'
+cache:
+  directories:
+  - "$HOME/.m2"
+before_script:
+  - "export JAVA_OPTS=-Xmx512m"
+  - "echo $JAVA_OPTS"
+  - lein clean
+script:
+- lein eastwood
+- lein kibit
+branches:
+  only:
+  - master
+  - mainline
+notifications:
+  slack:
+    secure: ARbvDz3oduvMPxFD5IwSgcygyajJJUQ8Vu9saa8RWuHuFjERT8Kh0KC9diKgISHgBZyRmUkiL+2hO/ICMg6R+CpFmkKfzZXZbLXeAL2yi3/Pm4vRVohhQFBDtYE9eby/yxSmKXcuBRpPdBTNilw3q+MITBOqn1lBZIBPKF5NgCakIEq+RSvv8ImSqqw1qKpAJrzBQpS3mriVEQJQgof70G1sY6RvCgCV5rvxiKD/xJp+qdSaVcT/qpTN5FZ/0dy+wSKjwOUOlr6FtbAjglrX5WnpHV072HTNtYqqdGa7n8MzxxN8N93F2ehC9xQqvYDg6O/OJjCz46idKV+TsYpi01aX0KAkuEelAhwhKhL/2TBN78Qf0edyKBEJqQHbYok7zNsbDUTblCOWgKqED/mAbC8BsmVgjpRlDcxtyxIDu1j3Fo8qXVlMtckZVfqu+GCA3RlVenqHi/GenjyFTIqQjK/y9KwAMLkmXQQVHNv1praTI8x4nOSqYcdsH2yGaTSWnZME29mUMgdN4F7gZfXWAeg11w3kvWuagDTn53cpZbaHPDYp9cQ9JdMCW6DJuG28zC9hCJc5atlwgs0ljoDwqV9/CPQtmjfnq1nMyhEcYeSX20E0vTzHL370Y6qyz9jBCI1Iw7seG5ozcR5KKhDbrweXaXpGd5CsO70BYSwqwUw=

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ To configure the Slack to use the ngrok tunnel as the destination of link_shared
 
 Click the "Event Subscriptions" navigation in the menu. Click the toggle on.
 
-Add the URL provided by ngrok above, modifying `http` to `https` and with a `/slack/unfurl` suffix,
-e.g. `https://6ae20d9b.ngrok.io/slack/unfurl`
+Add the URL provided by ngrok above, modifying `http` to `https` and with a `/slack-event` suffix,
+e.g. `https://6ae20d9b.ngrok.io/slack-event`
 
  Click the "Add Team Event" button and add the `link_shared` event. Click the "Add Bot User Event" button and
  add the `link_shared` event.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Make sure you update the `CHANGE-ME` items in the section of the `project.clj` t
     :open-company-slack-client-secret "CHANGE-ME"
     :aws-access-key-id "CHANGE-ME"
     :aws-secret-access-key "CHANGE-ME"
-    :aws-sns-slack-topic-arn "" ; SNS topic to publish notifications (optional)
+    :aws-sns-slack-topic-arn "CHANGE-ME" ; SNS topic to publish notifications (optional)
     :log-level "debug"
   }
 ```
@@ -194,7 +194,6 @@ The Slack Router service current has two responsibilities:
 
 - Process unfurl requests
 - Post Slack message events to an SNS topic.
-
 
 
 ## Participation

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Make sure you update the `CHANGE-ME` items in the section of the `project.clj` t
     :open-company-slack-client-secret "CHANGE-ME"
     :aws-access-key-id "CHANGE-ME"
     :aws-secret-access-key "CHANGE-ME"
-    :aws-sns-slack-topic-arn "CHANGE-ME" ; SNS topic to publish notifications (optional)
+    :aws-sns-slack-topic-arn "CHANGE-ME" ; SNS topic to publish notifications
     :log-level "debug"
   }
 ```

--- a/project.clj
+++ b/project.clj
@@ -171,7 +171,7 @@
 
   :aliases{
     "build" ["do" "clean," "deps," "compile"] ; clean and build code
-    "start" ["do" "migrate-db," "run" "-m" "oc.slack-router.app"] ; start a development server
+    "start" ["do" "run" "-m" "oc.slack-router.app"] ; start a development server
     "start!" ["with-profile" "prod" "do" "start"] ; start a server in production
     "midje!" ["with-profile" "qa" "midje"] ; run all tests
     "test!" ["with-profile" "qa" "do" "clean," "build," "midje"] ; build, init the DB and run all tests

--- a/src/oc/slack_router/api/slack.clj
+++ b/src/oc/slack_router/api/slack.clj
@@ -100,7 +100,7 @@
            [true, {:body body :challenge challenge}]))))
     })
   ;; Responses
-  :post! (fn [ctx] (slack-event-handler ctx))
+  :post! slack-event-handler
   
   :handle-created (fn [ctx]
     (timbre/debug "OK" (:type ctx) (:challenge ctx))

--- a/src/oc/slack_router/components.clj
+++ b/src/oc/slack_router/components.clj
@@ -2,8 +2,7 @@
   (:require [com.stuartsierra.component :as component]
             [taoensso.timbre :as timbre]
             [org.httpkit.server :as httpkit]
-            [oc.slack-router.async.slack-sns :as slack-sns]
-            [oc.slack-router.config :as c]))
+            [oc.slack-router.async.slack-sns :as slack-sns]))
 
 (defrecord HttpKit [options handler server]
   component/Lifecycle


### PR DESCRIPTION
To be reviewed with https://github.com/open-company/open-company-interaction/pull/18

Follow the README to get the service running locally.
Since this is the initial review, make sure to go through all the code. Not just the changes here.

To deploy use https://github.com/belucid/open-company-infrastructure/pull/64