### PR TITLE
Make slack url unfurling a little more robust.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ## Background
 
-> I've come to learn there is a virtuous cycle to transparency and a very vicious cycle of obfuscation.
+> I think the currency of leadership is transparency. You've got to be truthful. I don't think you should be vulnerable every day, but there are moments where you've got to share your soul and conscience with people and show them who you are, and not be afraid of it.
 
-> -- [Jeff Weiner](https://www.linkedin.com/in/jeffweiner08)
+> -- Howard Schultz
 
 Companies struggle to keep everyone on the same page. People are hyper-connected in the moment but still don’t know what’s happening across the company. Employees and investors, co-founders and execs, customers and community, they all want more transparency. The solution is surprisingly simple and effective - great company updates that build transparency and alignment.
 
@@ -77,7 +77,7 @@ A secret is shared between the [Slack Router service](https://github.com/open-co
 
 A [Slack App](https://api.slack.com/apps) needs to be created for OAuth authentication and events. For local development, create a Slack app with a Redirect URI of `http://localhost:3003/slack-oauth` and get the client ID and secret from the Slack app you create.  From the /apps url you will be able to chose 'Event Subscriptions' and then turn on the 'Enable Events' toggle.  Once this is turned on the router will begin receiving events from Slack.
 
-An [AWS SNS](https://aws.amazon.com/sns/) pub/sub topic is used to push slack events to interested listeners. To take advantage of this capability, configure the `aws-sns-slack-topic-arn` with the ARN (Amazon Resource Name) of the SNS topic you setup in AWS.
+An [AWS SNS](https://aws.amazon.com/sns/) pub/sub topic is used to push slack events to interested listeners, such as the OpenCompany Interaction Service. To take advantage of this capability, configure the `aws-sns-slack-topic-arn` with the ARN (Amazon Resource Name) of the SNS topic you setup in AWS.
 
 Make sure you update the `CHANGE-ME` items in the section of the `project.clj` that looks like this to contain your actual JWT, Slack, and AWS secrets:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ To get started, head to: [Carrot](https://carrot.io/)
 
 ## Overview
 
-The OpenCompany Slack Router service handles incoming events from the Slack API. It will then post these messages to an Amazon SNS topic so that other services can take action. It also handles the url unfurl requests.
+The OpenCompany Slack Router service handles incoming events from the Slack API. It will then post these messages to an Amazon SNS topic so that other services can take action.
+
+In addition, the Slack Router also handles the Carrot URL unfurl requests from Slack.
 
 
 ## Local Setup
@@ -118,28 +120,31 @@ First start the Slack Router Service (see below), and start the ngrok tunnel:
 ngrok http 3009
 ```
 
-Note the URL ngrok provides. It will look like: `http://6ae20d9b.ngrok.io` -> localhost:3009
+Note the HTTPS URL ngrok provides. It will look like: `https://6ae20d9b.ngrok.io` -> localhost:3009
 
 To configure the Slack to use the ngrok tunnel as the destination of link_shared events. Go to
 [Your Apps](https://api.slack.com/apps) and click the "Carrot (Local Development)" app.
 
-Click the "Event Subscriptions" navigation in the menu. Click the toggle on.
+Click the "Event Subscriptions" navigation item in the menu. Click the toggle on.
 
-Add the URL provided by ngrok above, modifying `http` to `https` and with a `/slack-event` suffix,
+Add the URL provided by ngrok above, modifying with a `/slack-event` suffix,
 e.g. `https://6ae20d9b.ngrok.io/slack-event`
 
- Click the "Add Team Event" button and add the `link_shared` event. Click the "Add Bot User Event" button and
- add the `link_shared` event.
+- Click the "Add Team Event" button and add the `link_shared` event.
+- Click the "Add Bot User Event" button and add the `link_shared` event.
+- Click the "Add Team Event" button and add the `messages.channels` event.
+- Click the "Add Bot User Event" button and add the `message.channels` event. - Click the "Add Bot User Event" button and add the `message.im` event.
 
 Click the "Save Changes" button.
 
-You will need to add domains to the slack app configuration.
-`localhost` for local dev
-`staging.carrot.io` for staging
-`beta.carrot.io` for beta
+You will need to add domains to the slack app configuration comensurate with where you are setting this up for. E.g.
 
-NB: Make sure when you are done testing locally, you disable the "Enable Events" toggle so Slack will stop trying
-to echo events to your local environment via ngrok.
+- `localhost` for local dev
+- `staging.<your-domain>` for staging
+- `beta.<your-domain>` for beta
+- `<your-domain>` for production
+
+NB: Make sure when you are done testing locally, you disable the "Enable Events" toggle so Slack will stop trying to echo events to your local environment via ngrok.
 
 To receive events from the SNS topic with SQS, you will need to subscribe an SQS queue to the topic.
 

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
     ;; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/clojure "1.9.0"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
-    [org.clojure/tools.cli "0.3.5"]
+    [org.clojure/tools.cli "0.3.7"]
     [http-kit "2.3.0-beta2"] ; Web client/server http://http-kit.org/
     ;; Web application library https://github.com/ring-clojure/ring
     [ring/ring-devel "1.6.3"]
@@ -31,15 +31,15 @@
     ;; NB: com.taoensso/timbre pulled in by oc.lib
     [ring-logger-timbre "0.7.6" :exclusions [com.taoensso/encore com.taoensso/timbre]] 
     ;; Web routing https://github.com/weavejester/compojure
-    [compojure "1.6.0"]
+    [compojure "1.6.1"]
     ;; Clojure Slack REST API https://github.com/julienXX/clj-slack
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
     [org.julienxx/clj-slack "0.5.6" :exclusions [clj-http org.clojure/data.json]]
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
-    [zprint "0.4.7"]
+    [zprint "0.4.9"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/dakrone/clj-http
-    [clj-http "3.8.0"]
+    [clj-http "3.9.0"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/clojure/data.json
     [org.clojure/data.json "0.2.6"]
 
@@ -90,7 +90,7 @@
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.6-beta2"]
+        [jonase/eastwood "0.2.6"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: org.clojure/tools.reader pulled in manually
@@ -132,7 +132,7 @@
         ;; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: rewrite-cljs not needed
-        [lein-zprint "0.3.8" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
+        [lein-zprint "0.3.9" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
       ]
     }]
 

--- a/src/oc/slack_router/api/slack.clj
+++ b/src/oc/slack_router/api/slack.clj
@@ -64,8 +64,9 @@
         (let [slack-users (get body "authed_users")
               slack-team-id (get body "team_id")]
           (doseq [slack-user slack-users]
-              (let [user-token (auth/user-token slack-user slack-team-id)]
-                (render-slack-unfurl user-token body))))
+            (let [user-token (auth/user-token slack-user slack-team-id)]
+              (when user-token
+                (render-slack-unfurl user-token body)))))
         :default
         (slack-sns/send-trigger! body)))
      :default

--- a/src/oc/slack_router/api/slack.clj
+++ b/src/oc/slack_router/api/slack.clj
@@ -104,7 +104,7 @@
   :post! slack-event-handler
   
   :handle-created (fn [ctx]
-    (timbre/debug "OK" (:type ctx) (:challenge ctx))
+    (timbre/debug "OK" (or (:type ctx) "") (or (:challenge ctx) ""))
     (when (= (:type ctx) "url_verification")
       (json/generate-string (:challenge ctx)))))
 

--- a/src/oc/slack_router/app.clj
+++ b/src/oc/slack_router/app.clj
@@ -48,6 +48,11 @@
     "Running on port: " port "\n"
     "Trace: " c/liberator-trace "\n"
     "Hot-reload: " c/hot-reload "\n"
+    "Slack client ID: " c/slack-client-id "\n"
+    "Auth Service: " c/auth-server-url "\n"
+    "Storage Service: " c/storage-server-url "\n"
+    "UI Server: " c/ui-server-url "\n"
+    "SNS Topic ARN: " c/aws-sns-slack-topic-arn "\n"
     "Sentry: " c/dsn "\n\n"
     (when c/intro? "Ready to serve...\n"))))
 

--- a/src/oc/slack_router/auth.clj
+++ b/src/oc/slack_router/auth.clj
@@ -22,4 +22,8 @@
              "Authorization" (str "Bearer " token)}})
 
 (defn user-token [slack-user slack-team-id]
-  (:body @(http/get request-token-url (get-options (magic-token slack-user slack-team-id)))))
+  (let [token-request
+        @(http/get request-token-url
+                   (get-options (magic-token slack-user slack-team-id)))]
+    (when (= 201 (:status token-request))
+      (:body token-request))))

--- a/src/oc/slack_router/config.clj
+++ b/src/oc/slack_router/config.clj
@@ -29,22 +29,27 @@
 (defonce auth-server-port (Integer/parseInt (or (env :auth-server-port) "3003")))
 (defonce slack-router-server-port (Integer/parseInt (or (env :port) "3009")))
 (defonce storage-server-port (Integer/parseInt (or (env :storage-server-port) "3001")))
+
 ;; ----- Liberator -----
+
 ;; see header response, or http://localhost:3009/x-liberator/requests/ for trace results
 (defonce liberator-trace (bool (or (env :liberator-trace) false)))
 (defonce pretty? (not prod?)) ; JSON response as pretty?
 
 ;; ----- URLs -----
+
 (defonce auth-server-url (or (env :auth-server-url) (str "http://localhost:" auth-server-port)))
 (defonce storage-server-url (or (env :storage-server-url) (str "http://localhost:" storage-server-port)))
 (defonce slack-router-server-url (or (env :slack-router-server-url) (str "http://localhost:" slack-router-server-port)))
 (defonce ui-server-url (or (env :ui-server-url) "http://localhost:3559"))
 
 ;; ----- AWS -----
+
 (defonce aws-access-key-id (env :aws-access-key-id))
 (defonce aws-secret-access-key (env :aws-secret-access-key))
 
 ;; ----- AWS SNS -----
+
 (defonce aws-sns-slack-topic-arn (env :aws-sns-slack-topic-arn))
   
 ;; ----- JWT -----

--- a/src/oc/slack_router/slack_unfurl.clj
+++ b/src/oc/slack_router/slack_unfurl.clj
@@ -167,7 +167,6 @@
    Also see open-company-lib for slack unfurl function.
   "
   [token channel ts url data]
-  (timbre/debug "RETUNED DATA: " data)
   (when data
     (let [url-data (cond
 
@@ -277,4 +276,4 @@
                      channel
                      message_ts
                      link
-                     data)))))))
+                     (assoc data "board-slug" (:section parsed-link)))))))))


### PR DESCRIPTION
Also fixes the missing board name.

See https://github.com/open-company/open-company-auth/pull/43
for testing instructions.