### PR TITLE
Reduce unfurl body

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,14 +16,14 @@
     [org.clojure/clojure "1.9.0"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.3.7"]
-    [http-kit "2.3.0-beta2"] ; Web client/server http://http-kit.org/
+    [http-kit "2.3.0"] ; Web client/server http://http-kit.org/
     ;; Web application library https://github.com/ring-clojure/ring
-    [ring/ring-devel "1.6.3"]
+    [ring/ring-devel "1.7.0-RC1"]
     ;; Web application library https://github.com/ring-clojure/ring
     ;; NB: clj-time pulled in by oc.lib
     ;; NB: joda-time pulled in by oc.lib via clj-time
     ;; NB: commons-codec pulled in by oc.lib
-    [ring/ring-core "1.6.3" :exclusions [clj-time joda-time commons-codec]]
+    [ring/ring-core "1.7.0-RC1" :exclusions [clj-time joda-time commons-codec]]
     ;; CORS library https://github.com/jumblerg/ring.middleware.cors
     [jumblerg/ring.middleware.cors "1.0.1"]
     ;; Ring logging https://github.com/nberger/ring-logger-timbre
@@ -48,7 +48,7 @@
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     ;; NB: clj-http pulled in manually
     ;; NB: org.clojure/data.json pulled in manually
-    [open-company/lib "0.16.5" :exclusions [clj-http org.clojure/data.json]]
+    [open-company/lib "0.16.10" :exclusions [clj-http org.clojure/data.json]]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let
@@ -82,7 +82,7 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.2-alpha3" :exclusions [joda-time clj-time commons-codec]] 
+        [midje "1.9.2" :exclusions [joda-time clj-time commons-codec]] 
         ;; Test Ring requests https://github.com/weavejester/ring-mock
         [ring-mock "0.1.5"]
       ]
@@ -90,7 +90,7 @@
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.6"]
+        [jonase/eastwood "0.2.9"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: org.clojure/tools.reader pulled in manually
@@ -99,7 +99,7 @@
         ;; NB: org.clojure/tools.reader pulled in manually
         [rewrite-clj "0.6.0" :exclusions [org.clojure/tools.reader]]
         ;; Not used directly, dependency of lein-kibit and rewrite-clj https://github.com/clojure/tools.reader
-        [org.clojure/tools.reader "1.3.0-alpha3"]
+        [org.clojure/tools.reader "1.3.0"]
       ]
     }
 

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.9.0"]
+    [org.clojure/clojure "1.10.0-alpha6"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.3.7"]
     [http-kit "2.3.0"] ; Web client/server http://http-kit.org/
@@ -37,7 +37,7 @@
     ;; NB: org.clojure/data.json pulled in manually
     [org.julienxx/clj-slack "0.5.6" :exclusions [clj-http org.clojure/data.json]]
     ;; Pretty-print clj and EDN https://github.com/kkinnear/zprint
-    [zprint "0.4.9"]
+    [zprint "0.4.10"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/dakrone/clj-http
     [clj-http "3.9.0"]
     ;; Not used directly, dependency of oc.lib and org.julienxx/clj-slack https://github.com/clojure/data.json
@@ -132,7 +132,7 @@
         ;; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
         ;; NB: rewrite-clj is pulled in manually
         ;; NB: rewrite-cljs not needed
-        [lein-zprint "0.3.9" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
+        [lein-zprint "0.3.10" :exclusions [org.clojure/clojure rewrite-clj rewrite-cljs]]
       ]
     }]
 

--- a/src/oc/slack_router/slack_unfurl.clj
+++ b/src/oc/slack_router/slack_unfurl.clj
@@ -159,7 +159,9 @@
                    :author_icon org-logo
                    :title title
                    :title_link url-text
-                   :text reduced-content
+                   :text (if (< (count reduced-content) (count content))
+                              (str reduced-content " ...")
+                              content)
                    :footer footer
                    :attachment_type "default"
                    :color "good" ;; this can be a hex color

--- a/src/oc/slack_router/slack_unfurl.clj
+++ b/src/oc/slack_router/slack_unfurl.clj
@@ -126,6 +126,10 @@
 (defn post-unfurl-data
   [url post-data]
   (let [content (.text (soup/parse (get post-data "body")))
+        reduced-content (clojure.string/join " " ;; split into words
+                           (filter not-empty
+                             (take 20 ;; 20 words is the average long sentence
+                               (clojure.string/split content #" "))))
         title (.text (soup/parse (get post-data "headline")))
         board-slug (get post-data "board-slug")
         author (get (get post-data "publisher") "name")
@@ -155,7 +159,7 @@
                    :author_icon org-logo
                    :title title
                    :title_link url-text
-                   :text content
+                   :text reduced-content
                    :footer footer
                    :attachment_type "default"
                    :color "good" ;; this can be a hex color


### PR DESCRIPTION
This change reduces the content of the post to 20 words. I picked 20 since according to google the average long sentence is 20 words.

To test:

Paste a url of a post into a slack channel.  Slack bot must be installed to the org.

- [x] Do you see the unfurled post and is the content reduced if it is over 20 words?
- [x] For content less than 20 is it displayed normally?

