### PR TITLE
Multiple authed users

### DIFF
--- a/src/oc/slack_router/api/slack.clj
+++ b/src/oc/slack_router/api/slack.clj
@@ -145,8 +145,9 @@
                                  (conj acc emessage))))
                            []
                            slack-users)]
-          (when (pos? (count errors?))
-            (throw (Exception. (str errors?)))))
+          (if (pos? (count errors?))
+            (throw (Exception. (str errors?)))
+            errors?))
         :default
         (slack-sns/send-trigger! body)))
      :default

--- a/src/oc/slack_router/api/slack.clj
+++ b/src/oc/slack_router/api/slack.clj
@@ -136,9 +136,13 @@
                  (reduced acc)
                  (catch Exception e
                    (do
-                     (timbre/info "Exception on slack unfurl" e)
+                     (timbre/error "Exception on slack unfurl:" e)
                      (inc acc))))
-               (inc acc)))
+               (do
+                 (timbre/info "Missing jwt token for user: "
+                              slack-user
+                              slack-team-id)
+                 (inc acc))))
            0
            slack-users))
         :default

--- a/src/oc/slack_router/api/slack.clj
+++ b/src/oc/slack_router/api/slack.clj
@@ -124,10 +124,9 @@
         ;; https://api.slack.com/docs/message-link-unfurling
         (let [slack-users (get body "authed_users")
               slack-team-id (get body "team_id")]
-          (timbre/debug slack-users)
+          (timbre/debug "LINKED SHARED EVENT:" slack-users slack-team-id)
           (reduce ;; iterate through list and stop on first success
            (fn [acc slack-user]
-             (timbre/debug slack-user)
              (if-let [user-token (auth/user-token
                                     {:slack-user-id slack-user
                                      :slack-team-id slack-team-id}
@@ -136,6 +135,7 @@
                                     "Slack Router")]
                (try
                  (render-slack-unfurl user-token body)
+                 (timbre/debug "REDUCED!!! " slack-user)
                  (reduced acc)
                  (catch Exception e
                    (do

--- a/src/oc/slack_router/api/slack.clj
+++ b/src/oc/slack_router/api/slack.clj
@@ -12,7 +12,6 @@
             [oc.slack-router.config :as config]))
 
 (defn render-slack-unfurl [token body]
-  (timbre/debug "render unfurl: " token body)
   (let [event (get body "event")
         links (get event "links")
         message_ts (get event "message_ts")
@@ -124,7 +123,6 @@
         ;; https://api.slack.com/docs/message-link-unfurling
         (let [slack-users (get body "authed_users")
               slack-team-id (get body "team_id")]
-          (timbre/debug "LINKED SHARED EVENT:" slack-users slack-team-id)
           (reduce ;; iterate through list and stop on first success
            (fn [acc slack-user]
              (if-let [user-token (auth/user-token
@@ -135,7 +133,6 @@
                                     "Slack Router")]
                (try
                  (render-slack-unfurl user-token body)
-                 (timbre/debug "REDUCED!!! " slack-user)
                  (reduced acc)
                  (catch Exception e
                    (do

--- a/src/oc/slack_router/api/slack.clj
+++ b/src/oc/slack_router/api/slack.clj
@@ -146,7 +146,7 @@
                            []
                            slack-users)]
           (if (pos? (count errors?))
-            (throw (Exception. (str errors?)))
+            (throw (ex-info (str "Slack link_shared errors:" (count errors?)) {:errors errors?}))
             errors?))
         :default
         (slack-sns/send-trigger! body)))

--- a/src/oc/slack_router/api/slack.clj
+++ b/src/oc/slack_router/api/slack.clj
@@ -136,10 +136,10 @@
                              (reduced [])
                              (catch Exception e
                                (do
-                                 (timbre/error "Exception on slack unfurl:" e)
+                                 (timbre/error "Exception on slack unfurl: " e)
                                  (conj acc e))))
                            (let [emessage (str "Missing jwt token for user: "
-                                               slack-user
+                                               slack-user " "
                                                slack-team-id)]
                                  (timbre/info emessage)
                                  (conj acc emessage))))


### PR DESCRIPTION
This change only uses one successful slack unfurl and skips the rest of the authed users.

To test:
you can test on staging or follow the README to test locally.

- post a url in a slack channel
- [x] before this change it would unfurl multiple times, now it is only once.