### PR TITLE
Fix unfurl

### DIFF
--- a/src/oc/slack_router/slack_unfurl.clj
+++ b/src/oc/slack_router/slack_unfurl.clj
@@ -178,11 +178,6 @@
         content (.text (soup/parse html-body))
         reduced-content (text/truncated-body content)
         headline (.text (soup/parse (:headline post-data)))
-        abstract (some-> (:abstract post-data) soup/parse .text)
-        must-see (:must-see post-data)
-        title (if must-see
-                (str "[Must see] " headline)
-                headline)
         board-name (:board-name post-data)
         publisher (:publisher post-data)
         author-name (user-lib/name-for publisher)
@@ -195,9 +190,9 @@
                   {
                    :author_name author-name-label
                    :author_icon author-avatar
-                   :title title
+                   :title headline
                    :title_link url-text
-                   :text (if (string/blank? abstract) reduced-content abstract)
+                   :text reduced-content
                    :thumb_url thumbnail-url
                    :attachment_type "default"
                    :color (vertical-line-color post-data) ;; this can be a hex color

--- a/src/oc/slack_router/slack_unfurl.clj
+++ b/src/oc/slack_router/slack_unfurl.clj
@@ -373,7 +373,8 @@
         :else
         (get-data url-type (storage-request-board-url (:org parsed-link) (:board parsed-link)) token
                   (fn [board-data]
-                    (when-not (= "private" (:access board-data))
+                    (if (= "private" (:access board-data))
+                      (timbre/warnf "Skipping unfurl for post %s, board %s has %s access" (:uuid parsed-link) (:board-uuid parsed-link) (:access board-data))
                       (get-data url-type request-url token
                                 (fn [data]
                                   (update-slack-url slack-token channel message_ts link

--- a/src/oc/slack_router/slack_unfurl.clj
+++ b/src/oc/slack_router/slack_unfurl.clj
@@ -205,8 +205,8 @@
    Also see open-company-lib for slack unfurl function.
   "
   [token channel ts url data]
-  (when data
-    (let [url-data (cond
+  (let [url-data (when data
+                   (cond
 
                     (and (:headline data) (:body data))
                     (post-unfurl-data url data)
@@ -224,9 +224,14 @@
                     (org-unfurl-data url data)
 
                     :else
-                    false)]
-      (timbre/info
-       (when url-data (slack-lib/unfurl-post-url token channel ts url-data))))))
+                    false))
+        unfurl-response (when url-data
+                          (slack-lib/unfurl-post-url token channel ts url-data))]
+    (if unfurl-response
+      (do
+        (timbre/infof "Slack unfurl did complete, output: %s" unfurl-response)
+        unfurl-response)
+      (timbre/errorf "Slack unfurl did NOT complete, data:\n%s\nurl-data:\n%s\nunfurl-response:\n%s" data url-data unfurl-response))))
 
 (defn parse-carrot-url [url]
   (let [split-url (string/split (:url url) #"/")


### PR DESCRIPTION
Trello card: https://trello.com/c/DrB9AccR/130-slack-unfurl-broken-at-least-for-hopper

Improvements to the unfurl handling: add more logging, improve error reporting and make sure the unfurling user is coming from the right key of the incoming payload.

Hopper's issue: in the end the issue that triggered this work was a mix of different problems. The initial unfurl didn't work because the bot was removed, or better the bot token was expired, when I went to check why it didn't work they had probably re-added it. Because of this "race-condition" I started investigating the logs and the code.

While investigating I improved the error reporting (before this service was reporting only the title of the 4 errors that were triggered during the different unfurl attempts, now it shows the full errors in the logs and report only a recap to Sentry).

After a few improvements I asked the Hopper's user to retry, this time they used a post from a private topic, my bad for not remembering that we do NOT unfurl posts from private topics to avoid informations leaks (this is a WIP for another feature that will use an ephemeral message to ask the user if they want to unfurl anyway).

Once I found that this time the problem was not a real error we attempted again the unfurl and it worked.
This PR then is mostly a code improvement.

Trello card: 

To test:
- open staging
- make sure the org you are using has the Slack bot
- find a post on staging not in a private topic and copy the url
- paste the url in a random Slack channel
- [ ] unfurl worked?
- repeat the above on production
- [ ] production worked too?
- merge

